### PR TITLE
chore: bump zip dependency to deflate-only features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ cc = { version = "1.2.30", optional = true }
 glob = { version = "0.3.2", optional = true }
 cmake = { version = "0.1.54", optional = true }
 reqwest = { version = "0.12.22", features = ["blocking"], optional = true }
-zip = { version = "2.4.2", optional = true }
+zip = { version = "7.2.0", default-features = false, features = ["deflate"], optional = true }
 
 
 [features]


### PR DESCRIPTION
bump zip version and only enable deflate feature