### PR TITLE
fix: correct TessBaseAPIInit4/Init5 FFI signatures to prevent SIGSEGV

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1104,6 +1104,10 @@ impl TesseractAPI {
                 oem,
                 config_ptr_ptrs.as_ptr(),
                 config_ptrs.len() as c_int,
+                std::ptr::null(),
+                std::ptr::null(),
+                0,
+                0,
             )
         };
         if result != 0 {
@@ -1150,6 +1154,10 @@ impl TesseractAPI {
                 oem,
                 config_ptr_ptrs.as_ptr(),
                 config_ptrs.len() as c_int,
+                std::ptr::null(),
+                std::ptr::null(),
+                0,
+                0,
             )
         };
         if result != 0 {
@@ -1521,6 +1529,10 @@ extern "C" {
         oem: c_int,
         configs: *const *const c_char,
         configs_size: c_int,
+        vars_vec: *const *const c_char,
+        vars_values: *const *const c_char,
+        vars_vec_size: usize,
+        set_only_non_debug_params: c_int,
     ) -> c_int;
     fn TessBaseAPIInit5(
         handle: *mut c_void,
@@ -1530,6 +1542,10 @@ extern "C" {
         oem: c_int,
         configs: *const *const c_char,
         configs_size: c_int,
+        vars_vec: *const *const c_char,
+        vars_values: *const *const c_char,
+        vars_vec_size: usize,
+        set_only_non_debug_params: c_int,
     ) -> c_int;
     fn TessBaseAPISetImage(
         handle: *mut c_void,


### PR DESCRIPTION
## Root cause
The `extern "C"` declarations for `TessBaseAPIInit4` and `TessBaseAPIInit5` were **truncated** — they declared 6/7 parameters, but the real Tesseract C API takes **10/11**:

```c
int TessBaseAPIInit4(TessBaseAPI*, const char* datapath, const char* language,
                     TessOcrEngineMode, char** configs, int configs_size,
                     char** vars_vec, char** vars_values, size_t vars_vec_size,
                     BOOL set_only_non_debug_params);
```

The trailing `vars_vec`, `vars_values`, `vars_vec_size`, `set_only_non_debug_params` were missing. Calling the real symbol with fewer args left the callee reading garbage for `vars_vec_size` and dereferencing garbage pointers → **SIGSEGV** in `init_4()`/`init_5()`.

This is what crashed `test_api` (isolated to `test_init_4` via `--test-threads=1`) and kept the **macOS** build job red since v0.2.0.

## Fix
Add the 4 missing params to both FFI declarations and pass `null`/`0` at the call sites (no variable-config injection, matching prior behavior).

## Verified (macOS, local)
Full suite green: `test_api` **92 passed** (was SIGSEGV), 180 tests total, 0 failures. `fmt` + `clippy` clean.