### PR TITLE
fix: correct remaining GetVariable FFI signatures found by audit

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -190,7 +190,13 @@ impl TesseractAPI {
             .handle
             .lock()
             .map_err(|_| TesseractError::MutexLockError)?;
-        Ok(unsafe { TessBaseAPIGetIntVariable(*handle, name.as_ptr()) })
+        let mut value: c_int = 0;
+        let ok = unsafe { TessBaseAPIGetIntVariable(*handle, name.as_ptr(), &mut value) };
+        if ok != 0 {
+            Ok(value)
+        } else {
+            Err(TesseractError::GetVariableError)
+        }
     }
 
     /// Gets a boolean variable.
@@ -208,7 +214,13 @@ impl TesseractAPI {
             .handle
             .lock()
             .map_err(|_| TesseractError::MutexLockError)?;
-        Ok(unsafe { TessBaseAPIGetBoolVariable(*handle, name.as_ptr()) } != 0)
+        let mut value: c_int = 0;
+        let ok = unsafe { TessBaseAPIGetBoolVariable(*handle, name.as_ptr(), &mut value) };
+        if ok != 0 {
+            Ok(value != 0)
+        } else {
+            Err(TesseractError::GetVariableError)
+        }
     }
 
     /// Gets a double variable.
@@ -226,7 +238,13 @@ impl TesseractAPI {
             .handle
             .lock()
             .map_err(|_| TesseractError::MutexLockError)?;
-        Ok(unsafe { TessBaseAPIGetDoubleVariable(*handle, name.as_ptr()) })
+        let mut value: c_double = 0.0;
+        let ok = unsafe { TessBaseAPIGetDoubleVariable(*handle, name.as_ptr(), &mut value) };
+        if ok != 0 {
+            Ok(value)
+        } else {
+            Err(TesseractError::GetVariableError)
+        }
     }
 
     /// Sets the page segmentation mode.
@@ -1454,9 +1472,21 @@ extern "C" {
         value: *const c_char,
     ) -> c_int;
     fn TessBaseAPIGetStringVariable(handle: *mut c_void, name: *const c_char) -> *const c_char;
-    fn TessBaseAPIGetIntVariable(handle: *mut c_void, name: *const c_char) -> c_int;
-    fn TessBaseAPIGetBoolVariable(handle: *mut c_void, name: *const c_char) -> c_int;
-    fn TessBaseAPIGetDoubleVariable(handle: *mut c_void, name: *const c_char) -> c_double;
+    fn TessBaseAPIGetIntVariable(
+        handle: *mut c_void,
+        name: *const c_char,
+        value: *mut c_int,
+    ) -> c_int;
+    fn TessBaseAPIGetBoolVariable(
+        handle: *mut c_void,
+        name: *const c_char,
+        value: *mut c_int,
+    ) -> c_int;
+    fn TessBaseAPIGetDoubleVariable(
+        handle: *mut c_void,
+        name: *const c_char,
+        value: *mut c_double,
+    ) -> c_int;
     fn TessBaseAPISetPageSegMode(handle: *mut c_void, mode: c_int);
     fn TessBaseAPIGetPageSegMode(handle: *mut c_void) -> c_int;
     fn TessBaseAPIRecognize(handle: *mut c_void, monitor: *mut c_void) -> c_int;
@@ -1653,20 +1683,10 @@ extern "C" {
         raw_image: c_int,
         raw_padding: c_int,
         pixa: *mut *mut c_void,
+        blockids: *mut *mut c_int,
+        paraids: *mut *mut c_int,
     ) -> *mut c_void;
-    fn TessBaseAPIProcessPagesWithOptions(
-        handle: *mut c_void,
-        filename: *const c_char,
-        retry_config: *const c_char,
-        timeout_millisec: c_int,
-        renderer: *mut c_void,
-    ) -> *mut c_char;
     fn TessBaseAPIOem(handle: *mut c_void) -> c_int;
-    fn TessBaseAPIGetBlockTextOrientations(
-        handle: *mut c_void,
-        block_orientation: *mut *mut c_int,
-        vertical_writing: *mut bool,
-    );
     fn TessPageIteratorCopy(handle: *mut c_void) -> *mut c_void;
     fn TessPageIteratorGetBinaryImage(handle: *mut c_void, level: c_int) -> *mut c_void;
     fn TessPageIteratorGetImage(

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -53,44 +53,37 @@ fn test_get_string_variable() {
 #[test]
 fn test_get_int_variable() {
     let api = create_initialized_api();
-    // "editor_image_word_bb_color" is a known int variable in Tesseract
-    let val = api.get_int_variable("editor_image_word_bb_color");
-    // Just verify it doesn't crash and returns a result
-    assert!(
-        val.is_ok(),
-        "get_int_variable should succeed for a known int variable"
-    );
+    // Registered int parameter (default 10 in Tesseract). Before the FFI fix
+    // this returned the BOOL success flag (0/1); now it returns the real value.
+    let val = api
+        .get_int_variable("edges_max_children_per_outline")
+        .expect("get_int_variable should succeed for a known int variable");
+    assert_eq!(val, 10);
 }
 
 // ---------------------------------------------------------------------------
-// 5. get_bool_variable()
+// 5. get_bool_variable()  (re-enabled after the FFI signature fix)
 // ---------------------------------------------------------------------------
-// NOTE: Skipped - TessBaseAPIGetBoolVariable FFI binding has incorrect
-// signature (missing output pointer parameter), causing SIGSEGV.
-// This is a known wrapper bug. Uncomment when the FFI binding is fixed.
-// #[test]
-// fn test_get_bool_variable() {
-//     let api = create_initialized_api();
-//     let val = api
-//         .get_bool_variable("tessedit_ambigs_training")
-//         .expect("get_bool_variable failed");
-//     assert!(!val, "tessedit_ambigs_training default should be false");
-// }
+#[test]
+fn test_get_bool_variable() {
+    let api = create_initialized_api();
+    let val = api
+        .get_bool_variable("tessedit_ambigs_training")
+        .expect("get_bool_variable failed");
+    assert!(!val, "tessedit_ambigs_training default should be false");
+}
 
 // ---------------------------------------------------------------------------
-// 6. get_double_variable()
+// 6. get_double_variable()  (re-enabled after the FFI signature fix)
 // ---------------------------------------------------------------------------
-// NOTE: Skipped - TessBaseAPIGetDoubleVariable FFI binding has incorrect
-// signature (missing output pointer parameter), causing SIGSEGV.
-// This is a known wrapper bug. Uncomment when the FFI binding is fixed.
-// #[test]
-// fn test_get_double_variable() {
-//     let api = create_initialized_api();
-//     let val = api
-//         .get_double_variable("tessedit_reject_doc_percent")
-//         .expect("get_double_variable failed");
-//     assert!(val.is_finite(), "Should return a finite f64, got {}", val);
-// }
+#[test]
+fn test_get_double_variable() {
+    let api = create_initialized_api();
+    let val = api
+        .get_double_variable("tessedit_reject_doc_percent")
+        .expect("get_double_variable failed");
+    assert!(val.is_finite(), "Should return a finite f64, got {}", val);
+}
 
 // ---------------------------------------------------------------------------
 // 7. set_page_seg_mode / get_page_seg_mode roundtrip


### PR DESCRIPTION
Follow-up to #27. I audited **every** `extern "C"` declaration (135 across all 6 src files) against tesseract 5.5.2 `capi.h`. All mismatches were in `src/api.rs`:

| Function | Problem | Called? |
|----------|---------|---------|
| `GetIntVariable` / `GetBoolVariable` / `GetDoubleVariable` | missing trailing out-pointer (`int*`/`BOOL*`/`double*`); returns BOOL | **yes** (get_*_variable) |
| `GetComponentImages1` | 6 vs 8 params (missing `int** blockids/paraids`) | no (dead decl) |
| `ProcessPagesWithOptions` | no such C symbol | no |
| `GetBlockTextOrientations` | wrong symbol name (`TessBase…` not `TessBaseAPI…`) | no |

The three `Get*Variable` wrappers were returning the **BOOL success flag as the value** and making the C side write through an uninitialized pointer → wrong results + potential SIGSEGV (same class as #27's Init4/Init5).

**Fixes:** add the out-params, return the written value, `Err` on lookup failure; correct `GetComponentImages1`; remove the two dead phantom decls.

Also re-enables `test_get_bool_variable` / `test_get_double_variable`, which the maintainer had disabled with an explicit *"known wrapper bug — uncomment when the FFI binding is fixed"* note, and points `test_get_int_variable` at a registered int parameter.

Verified locally: full suite green (`test_api` 94 passed).