### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-07-08
+
+### BREAKING CHANGES
+- Raised the minimum supported Rust version (MSRV) to **1.88** (required by the
+  upgraded dependencies).
+- `get_int_variable()`, `get_bool_variable()` and `get_double_variable()` now
+  return the actual variable value and `Err(GetVariableError)` when the
+  variable is not found, instead of the C `BOOL` success flag.
+
+### Added
+- FreeBSD support — the build and full test suite now run on FreeBSD in CI
+  (via a FreeBSD VM).
+- `embed-tessdata` feature: embed `.traineddata` directly into the compiled
+  binary and load it at runtime with `init_embedded()` / `embedded_languages()`.
+
+### Changed
+- Upgraded the bundled Tesseract **5.3.4 → 5.5.2** and Leptonica
+  **1.84.1 → 1.87.0**, now compiled with C++17.
+- Upgraded all dependencies to their latest versions (thiserror 2, reqwest
+  0.13, zip 7 deflate-only, imageproc 0.27, etc.).
+
+### Fixed
+- Fixed a SIGSEGV caused by truncated `TessBaseAPIInit4` / `TessBaseAPIInit5`
+  FFI signatures (missing trailing parameters).
+- Fixed the `TessBaseAPIGet{Int,Bool,Double}Variable` FFI signatures (missing
+  output pointer), which returned wrong values and could corrupt memory.
+- Fixed the Windows debug build failing to locate the `d`-suffixed static
+  libraries (#17).
+
+### Contributors
+- FreeBSD support and the `embed-tessdata` feature were contributed by
+  [@mwstowe](https://github.com/mwstowe) (#20).
+- The deflate-only `zip` configuration was contributed by
+  [@YageGeng](https://github.com/YageGeng) (#25).
+- The Windows debug-library and C++17 build fixes were cross-checked against
+  the maintained [xberg-tesseract](https://github.com/xberg-io/xberg) fork.
+
 ## [0.2.0] - 2026-03-23
 
 ### BREAKING CHANGES

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2259,7 +2259,7 @@ dependencies = [
 
 [[package]]
 name = "tesseract-rs"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "cc",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tesseract-rs"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Cafer Can Gündoğdu <cafercangundogdu@gmail.com>"]
 description = "Rust bindings for Tesseract OCR with optional built-in compilation"

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tesseract-rs = { version = "0.1.22", features = ["build-tesseract"] }
+tesseract-rs = { version = "0.3.0", features = ["build-tesseract"] }
 ```
 
 For single-binary deployment with embedded tessdata:
 
 ```toml
 [dependencies]
-tesseract-rs = { version = "0.1.22", features = ["embed-tessdata"] }
+tesseract-rs = { version = "0.3.0", features = ["embed-tessdata"] }
 ```
 
 By default, both English and Turkish tessdata are embedded. To embed only specific languages, set the `TESSERACT_EMBED_LANGUAGES` environment variable during build:
@@ -42,8 +42,8 @@ For development and testing, you'll also need these dependencies:
 
 ```toml
 [dev-dependencies]
-image = "0.25.5"
-imageproc = "0.25.0"
+image = "0.25.10"
+imageproc = "0.27.0"
 ```
 
 ## System Requirements
@@ -53,7 +53,7 @@ To build this crate, you need:
 - A C++ compiler (e.g., gcc, clang)
 - CMake
 - Internet connection (for downloading Tesseract training data)
-- Rust 1.83.0 or later
+- Rust 1.88 or later
 
 ## Environment Variables
 
@@ -95,8 +95,8 @@ The project includes several integration tests that verify OCR functionality. To
 
    ```toml
    [dev-dependencies]
-   image = "0.25.5"
-   imageproc = "0.25.0"
+   image = "0.25.10"
+   imageproc = "0.27.0"
    ```
 
 2. Run the tests:
@@ -183,7 +183,7 @@ fn get_tessdata_dir() -> PathBuf {
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let api = TesseractAPI::new()?;
+    let api = TesseractAPI::new();
 
     // Get tessdata directory (uses default location or TESSDATA_PREFIX if set)
     let tessdata_dir = get_tessdata_dir();
@@ -259,7 +259,7 @@ use tesseract_rs::TesseractAPI;
 use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let api = TesseractAPI::new()?;
+    let api = TesseractAPI::new();
     
     // Initialize with embedded tessdata - no external files needed!
     api.init_embedded("eng")?;
@@ -330,7 +330,7 @@ use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let tessdata_dir = get_tessdata_dir();
-    let api = TesseractAPI::new()?;
+    let api = TesseractAPI::new();
 
     // Initialize the main API
     api.init(tessdata_dir.to_str().unwrap(), "eng")?;
@@ -345,7 +345,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Spawn multiple threads for parallel OCR processing
     for _ in 0..3 {
-        let api_clone = api.clone(); // Clones the API with all configurations
+        let api_clone = api.try_clone()?; // Clone the API with all configurations
         let image_data = Arc::clone(&image_data);
 
         let handle = thread::spawn(move || {
@@ -409,7 +409,10 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Contributors
 
-- [Cafer Can Gündoğdu](https://github.com/cafercangundogdu)
+- [Cafer Can Gündoğdu](https://github.com/cafercangundogdu) — author and maintainer
+- [Michael Stowe](https://github.com/mwstowe) — FreeBSD support and embedded tessdata
+- [Yage](https://github.com/YageGeng) — deflate-only `zip` configuration
+- [York Xiang](https://github.com/bombless) — Windows `$HOME` handling
 
 ## Contributing
 
@@ -431,7 +434,3 @@ Our commit messages follow the [Conventional Commits](https://www.conventionalco
 ## Acknowledgements
 
 This project uses [Tesseract OCR](https://github.com/tesseract-ocr/tesseract) and [Leptonica](http://leptonica.org/). We are grateful to the maintainers and contributors of these projects.
-
-```
-
-```


### PR DESCRIPTION
Prepares the **0.3.0** release.

- `Cargo.toml`: version 0.2.0 → 0.3.0
- `CHANGELOG.md`: 0.3.0 entry (BREAKING / Added / Changed / Fixed + Contributors)
- `README.md`: version 0.1.22 → 0.3.0, MSRV 1.83 → 1.88, dev-dep versions, fixed broken examples (`new()?` → `new()`, `clone()` → `try_clone()?`), and a full contributors list

Contributors this cycle: @mwstowe (#20), @YageGeng (#25); historical: @bombless (#2).

After merge: tag `v0.3.0`, GitHub release, `cargo publish`.