### PR TITLE
fix: pin macOS deployment target to 10.15 for Tesseract build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-07-31
+
+### Fixed
+- Fixed the macOS build failing on Xcode 26+ runners: `std::filesystem` was
+  reported unavailable (introduced in macOS 10.15) because no deployment
+  target was set and the runner's default dropped below 10.15. The build now
+  pins `CMAKE_OSX_DEPLOYMENT_TARGET` / `-mmacosx-version-min` to 10.15 (#32).
+
+### Contributors
+- Reported by [@pndaza](https://github.com/pndaza) (#32).
+
 ## [0.3.0] - 2026-07-08
 
 ### BREAKING CHANGES

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2259,7 +2259,7 @@ dependencies = [
 
 [[package]]
 name = "tesseract-rs"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "cc",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tesseract-rs"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Cafer Can Gündoğdu <cafercangundogdu@gmail.com>"]
 description = "Rust bindings for Tesseract OCR with optional built-in compilation"

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tesseract-rs = { version = "0.3.0", features = ["build-tesseract"] }
+tesseract-rs = { version = "0.3.1", features = ["build-tesseract"] }
 ```
 
 For single-binary deployment with embedded tessdata:
 
 ```toml
 [dependencies]
-tesseract-rs = { version = "0.3.0", features = ["embed-tessdata"] }
+tesseract-rs = { version = "0.3.1", features = ["embed-tessdata"] }
 ```
 
 By default, both English and Turkish tessdata are embedded. To embed only specific languages, set the `TESSERACT_EMBED_LANGUAGES` environment variable during build:

--- a/build.rs
+++ b/build.rs
@@ -303,6 +303,21 @@ mod build_tesseract {
         if cfg!(target_os = "macos") {
             cmake_cxx_flags.push_str("-stdlib=libc++ ");
             cmake_cxx_flags.push_str("-std=c++17 ");
+            // Pin the deployment target to 10.15, the minimum macOS version
+            // that provides std::filesystem (used by Tesseract 5.x
+            // baseapi.cpp). Because CMAKE_CXX_FLAGS is set explicitly below,
+            // the cmake crate skips injecting the cc crate's
+            // -mmacosx-version-min into the C++ flags (it only does so for
+            // C/ASM). Without an explicit deployment target, Xcode 26+
+            // runners derive a default below 10.15 and the build fails
+            // (issue #32). CMAKE_OSX_DEPLOYMENT_TARGET is the authoritative
+            // cmake-level setting; the flag in CMAKE_CXX_FLAGS is redundant
+            // but keeps the two consistent.
+            cmake_cxx_flags.push_str("-mmacosx-version-min=10.15 ");
+            additional_defines.push((
+                "CMAKE_OSX_DEPLOYMENT_TARGET".to_string(),
+                "10.15".to_string(),
+            ));
         } else if cfg!(target_os = "linux") {
             cmake_cxx_flags.push_str("-std=c++17 ");
             // Check if we're on a system using clang


### PR DESCRIPTION
Fixes #32

## Problem

Building with the `build-tesseract` feature on GitHub Actions `macos-latest`
(Xcode 26+) fails while compiling `libtesseract` from source:

```
src/api/baseapi.cpp:150:25: error: 'recursive_directory_iterator' is
unavailable: introduced in macOS 10.15
```

Root cause: the build never sets a macOS deployment target. Because
`build.rs` passes `CMAKE_CXX_FLAGS` explicitly, the `cmake` crate skips
injecting the `cc` crate's `-mmacosx-version-min` into the C++ flags (it
only does so for C/ASM). With no deployment target set anywhere, Xcode 26+
runners derive a default below 10.15 and the C++ compile of Tesseract 5.x
(`std::filesystem` in `baseapi.cpp`) fails.

## Fix

- Set `CMAKE_OSX_DEPLOYMENT_TARGET=10.15` (authoritative cmake variable,
  applied to both the leptonica and tesseract builds)
- Also pass `-mmacosx-version-min=10.15` explicitly in `CMAKE_CXX_FLAGS`
  as belt-and-suspenders

10.15 is the minimum macOS version that provides `std::filesystem`.

## Verification

- Full clean build (`CARGO_CLEAN=1`) succeeds; `CMakeCache.txt` shows
  `CMAKE_OSX_DEPLOYMENT_TARGET=10.15` and compile lines carry
  `-mmacosx-version-min=10.15`
- Runner simulation: clean build with `MACOSX_DEPLOYMENT_TARGET=10.13`
  (below the 10.15 floor) also succeeds — the fix pins 10.15 regardless
  of the environment default
- `cargo test` passes (49 tests)
