### PR TITLE
feat: system Tesseract support, CLI tool, and ProcessPages FFI fix

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,9 @@ jobs:
       run: cargo fmt -- --check
     
     - name: Run clippy
-      run: cargo clippy -- -D warnings
+      run: |
+        cargo clippy -- -D warnings
+        cargo clippy -p tesseract-rs-cli -- -D warnings
       env:
         RUSTC_WRAPPER: ""
     
@@ -117,7 +119,9 @@ jobs:
         }
       
     - name: Build
-      run: cargo build --verbose
+      run: |
+        cargo build --verbose
+        cargo build -p tesseract-rs-cli --verbose
       env:
         RUSTC_WRAPPER: ""
       

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-07-31
+
+### Added
+- `use-system-tesseract` feature: link against a system-installed Tesseract
+  (Homebrew, `libtesseract-dev`, ...) via pkg-config instead of compiling the
+  bundled sources — builds go from minutes to seconds.
+- `tesseract-rs-cli` — a new command-line OCR tool (`tesseract-rs <image>`),
+  shipped as a workspace crate. Install via `cargo install tesseract-rs-cli`
+  (bundled Tesseract) or `cargo install tesseract-rs-cli --no-default-features
+  --features use-system-tesseract` (system Tesseract).
+
+### Fixed
+- `process_pages()` crashed with SIGSEGV on tesseract 5.5.3: the FFI
+  signature of `TessBaseAPIProcessPages` declared a `char *` return type,
+  but the C API returns `BOOL`. On success the value `1` was treated as a
+  pointer and dereferenced. The signature now returns `c_int` and the text
+  is fetched via `GetUTF8Text`.
+
 ## [0.3.1] - 2026-07-31
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2259,7 +2259,7 @@ dependencies = [
 
 [[package]]
 name = "tesseract-rs"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "cc",
  "cmake",
@@ -2268,9 +2268,18 @@ dependencies = [
  "image",
  "imageproc",
  "libc",
+ "pkg-config",
  "reqwest",
  "thiserror",
  "zip",
+]
+
+[[package]]
+name = "tesseract-rs-cli"
+version = "0.1.0"
+dependencies = [
+ "image",
+ "tesseract-rs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tesseract-rs"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 authors = ["Cafer Can Gündoğdu <cafercangundogdu@gmail.com>"]
 description = "Rust bindings for Tesseract OCR with optional built-in compilation"
@@ -19,7 +19,7 @@ categories = ["external-ffi-bindings", "computer-vision", "text-processing"]
 build = "build.rs"
 links = "tesseract"
 rust-version = "1.88"
-exclude = ["tessdata/*", "third_party/*"]
+exclude = ["tessdata/*", "third_party/*", "cli/*"]
 
 [dependencies]
 libc = "0.2.186"
@@ -38,12 +38,21 @@ reqwest = { version = "0.13.4", features = ["blocking"], optional = true }
 zip = { version = "8.6.0", default-features = false, features = [
     "deflate",
 ], optional = true }
+pkg-config = { version = "0.3.33", optional = true }
 
 
 [features]
 default = ["build-tesseract"]
 build-tesseract = ["cc", "glob", "cmake", "reqwest", "zip"]
+# Link against a system-installed Tesseract (e.g. `brew install tesseract`)
+# instead of compiling the bundled sources. Implies `build-tesseract` so the
+# FFI layer (which is gated on it) is always compiled.
+use-system-tesseract = ["pkg-config", "build-tesseract"]
 embed-tessdata = ["build-tesseract"]
+
+[workspace]
+members = ["cli"]
+default-members = ["."]
 
 [package.metadata.docs.rs]
 features = ["docs-only"]

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tesseract-rs = { version = "0.3.1", features = ["build-tesseract"] }
+tesseract-rs = { version = "0.4.0", features = ["build-tesseract"] }
 ```
 
 For single-binary deployment with embedded tessdata:
 
 ```toml
 [dependencies]
-tesseract-rs = { version = "0.3.1", features = ["embed-tessdata"] }
+tesseract-rs = { version = "0.4.0", features = ["embed-tessdata"] }
 ```
 
 By default, both English and Turkish tessdata are embedded. To embed only specific languages, set the `TESSERACT_EMBED_LANGUAGES` environment variable during build:
@@ -36,6 +36,40 @@ TESSERACT_EMBED_LANGUAGES=eng cargo build --features embed-tessdata
 
 # Embed multiple languages
 TESSERACT_EMBED_LANGUAGES=eng,fra,deu cargo build --features embed-tessdata
+```
+
+## Using a system-installed Tesseract
+
+Instead of compiling the bundled Tesseract/Leptonica sources (minutes), you
+can link against a system-installed Tesseract with the `use-system-tesseract`
+feature. The build then locates `tesseract.pc` via pkg-config:
+
+```toml
+[dependencies]
+tesseract-rs = { version = "0.4.0", default-features = false, features = ["use-system-tesseract"] }
+```
+
+```bash
+# macOS
+brew install tesseract
+
+# Debian/Ubuntu
+sudo apt install libtesseract-dev libleptonica-dev
+```
+
+`TESSDATA_PREFIX` or a tessdata directory passed to `init()` is still used to
+locate language data.
+
+## Command-line tool
+
+The workspace also ships `tesseract-rs-cli`, a small OCR command-line tool:
+
+```sh
+cargo install tesseract-rs-cli            # bundled Tesseract
+cargo install tesseract-rs-cli --no-default-features --features use-system-tesseract   # system Tesseract
+
+tesseract-rs image.png
+tesseract-rs -l eng+tur --psm 6 -o hocr scanned.png
 ```
 
 For development and testing, you'll also need these dependencies:

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,11 @@
 #![allow(clippy::uninlined_format_args)]
+// When both `build-tesseract` and `use-system-tesseract` are enabled, the
+// bundled-build module is compiled (it hosts shared helpers) but its build
+// entry point is not called — silence the resulting dead-code warnings.
+#![cfg_attr(
+    all(feature = "build-tesseract", feature = "use-system-tesseract"),
+    allow(dead_code)
+)]
 
 #[cfg(feature = "build-tesseract")]
 mod build_tesseract {
@@ -470,7 +477,7 @@ mod build_tesseract {
         extract_dir
     }
 
-    fn download_tessdata(project_dir: &Path) {
+    pub(crate) fn download_tessdata(project_dir: &Path) {
         let tessdata_dir = project_dir.join("tessdata");
         fs::create_dir_all(&tessdata_dir).expect("Failed to create Tessdata directory");
 
@@ -633,12 +640,56 @@ mod build_tesseract {
     }
 }
 
+#[cfg(feature = "use-system-tesseract")]
+mod system_tesseract {
+    use std::env;
+
+    /// Link against a system-installed Tesseract (Homebrew, libtesseract-dev,
+    /// etc.) instead of compiling the bundled sources.
+    ///
+    /// Uses pkg-config to locate `tesseract.pc`; leptonica is pulled in
+    /// transitively via the `Requires:` entry. libtesseract is C++, so the
+    /// C++ standard library runtime is linked explicitly.
+    pub fn link_system_tesseract() {
+        pkg_config::Config::new()
+            .probe("tesseract")
+            .expect("use-system-tesseract requires the Tesseract development library (e.g. `brew install tesseract` or `apt install libtesseract-dev`)");
+
+        if cfg!(target_os = "macos") {
+            println!("cargo:rustc-link-lib=c++");
+        } else if cfg!(target_os = "freebsd") {
+            println!("cargo:rustc-link-lib=c++");
+            println!("cargo:rustc-link-lib=pthread");
+        } else if cfg!(target_os = "linux") {
+            let uses_clang = env::var("CC")
+                .map(|cc| cc.contains("clang"))
+                .unwrap_or(false);
+            if uses_clang || cfg!(target_env = "musl") {
+                println!("cargo:rustc-link-lib=c++");
+            } else {
+                println!("cargo:rustc-link-lib=stdc++");
+            }
+            println!("cargo:rustc-link-lib=pthread");
+        }
+    }
+}
+
 fn main() {
-    #[cfg(feature = "build-tesseract")]
+    #[cfg(feature = "use-system-tesseract")]
+    system_tesseract::link_system_tesseract();
+
+    #[cfg(all(feature = "build-tesseract", not(feature = "use-system-tesseract")))]
     build_tesseract::build();
 
     #[cfg(feature = "embed-tessdata")]
-    generate_embedded_tessdata();
+    {
+        // In system mode the bundled build (which normally downloads the
+        // tessdata files) is skipped, so fetch them here for embedding.
+        #[cfg(feature = "use-system-tesseract")]
+        build_tesseract::download_tessdata(&build_tesseract::get_custom_out_dir());
+
+        generate_embedded_tessdata();
+    }
 }
 
 #[cfg(feature = "embed-tessdata")]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "tesseract-rs-cli"
+version = "0.1.0"
+edition = "2021"
+authors = ["Cafer Can Gündoğdu <cafercangundogdu@gmail.com>"]
+description = "Command-line OCR tool built on tesseract-rs"
+license = "MIT"
+repository = "https://github.com/cafercangundogdu/tesseract-rs"
+readme = "README.md"
+keywords = ["tesseract", "ocr", "cli", "command-line"]
+categories = ["command-line-utilities"]
+
+[dependencies]
+tesseract-rs = { version = "0.4.0", path = "..", default-features = false }
+image = "0.25.10"
+
+[features]
+default = ["bundled"]
+# Compile the bundled Tesseract/Leptonica sources (requires internet + cmake).
+bundled = ["tesseract-rs/build-tesseract"]
+# Link against a system-installed Tesseract (e.g. `brew install tesseract`).
+use-system-tesseract = ["tesseract-rs/use-system-tesseract"]
+
+[[bin]]
+name = "tesseract-rs"
+path = "src/main.rs"

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,40 @@
+# tesseract-rs-cli
+
+Command-line OCR tool built on [tesseract-rs](https://crates.io/crates/tesseract-rs).
+
+## Usage
+
+```sh
+tesseract-rs image.png
+tesseract-rs -l eng+tur --psm 6 document.png
+tesseract-rs -o hocr scanned.png > result.hocr
+```
+
+## Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-l, --lang <LANG>` | Language(s) to use (default: `eng`) |
+| `-p, --psm <MODE>` | Page segmentation mode 0-13 (default: 3 = auto) |
+| `-t, --tessdata <DIR>` | Tessdata directory (default: `TESSDATA_PREFIX`, then `tesseract --print-tessdata-dir`, then the compiled-in default) |
+| `-o, --output <FMT>` | Output format: `txt`, `hocr`, `tsv` (default: `txt`) |
+| `-v, --version` | Print version |
+| `-h, --help` | Print help |
+
+## Install
+
+```sh
+# Bundled Tesseract (compiled from source, no system dependency)
+cargo install tesseract-rs-cli
+
+# Or link against a system Tesseract (Homebrew)
+brew install tesseract
+cargo install tesseract-rs-cli --no-default-features --features use-system-tesseract
+```
+
+On macOS you can also use the Homebrew tap:
+
+```sh
+brew tap cafercangundogdu/tesseract-rs
+brew install tesseract-rs
+```

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,0 +1,231 @@
+use std::env;
+use std::path::PathBuf;
+use std::process::{Command, ExitCode};
+
+use tesseract_rs::{TessPageSegMode, TesseractAPI};
+
+const USAGE: &str = "\
+tesseract-rs — OCR from the command line
+
+Usage:
+  tesseract-rs [OPTIONS] <IMAGE>
+
+Options:
+  -l, --lang <LANG>     Language(s) to use (default: eng)
+  -p, --psm <MODE>      Page segmentation mode 0-13 (default: 3 = auto)
+  -t, --tessdata <DIR>  Tessdata directory (default: TESSDATA_PREFIX, then
+                        `tesseract --print-tessdata-dir`, then the
+                        compiled-in default)
+  -o, --output <FMT>    Output format: txt, hocr, tsv (default: txt)
+  -v, --version         Print version and exit
+  -h, --help            Print this help and exit
+";
+
+struct Options {
+    image: PathBuf,
+    lang: String,
+    psm: Option<i32>,
+    tessdata: Option<PathBuf>,
+    output: OutputFormat,
+}
+
+enum OutputFormat {
+    Txt,
+    Hocr,
+    Tsv,
+}
+
+fn main() -> ExitCode {
+    let args: Vec<String> = env::args().skip(1).collect();
+    let opts = match parse_args(&args) {
+        Ok(opts) => opts,
+        Err(err) => {
+            eprintln!("error: {err}\n\n{USAGE}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match run(&opts) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("error: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn parse_args(args: &[String]) -> Result<Options, String> {
+    let mut image = None;
+    let mut lang = "eng".to_string();
+    let mut psm = None;
+    let mut tessdata = None;
+    let mut output = OutputFormat::Txt;
+
+    let mut i = 0;
+    while i < args.len() {
+        let arg = args[i].as_str();
+        match arg {
+            "-h" | "--help" => {
+                print!("{USAGE}");
+                std::process::exit(0);
+            }
+            "-v" | "--version" => {
+                println!("tesseract-rs {}", env!("CARGO_PKG_VERSION"));
+                std::process::exit(0);
+            }
+            "-l" | "--lang" => {
+                i += 1;
+                lang = args.get(i).ok_or("--lang requires a value")?.clone();
+            }
+            "-p" | "--psm" => {
+                i += 1;
+                psm = Some(parse_psm(args.get(i).ok_or("--psm requires a value")?)?);
+            }
+            "-t" | "--tessdata" => {
+                i += 1;
+                tessdata = Some(PathBuf::from(
+                    args.get(i).ok_or("--tessdata requires a value")?,
+                ));
+            }
+            "-o" | "--output" => {
+                i += 1;
+                output = parse_output(args.get(i).ok_or("--output requires a value")?)?;
+            }
+            _ if arg.starts_with("--lang=") => lang = arg["--lang=".len()..].to_string(),
+            _ if arg.starts_with("--psm=") => psm = Some(parse_psm(&arg["--psm=".len()..])?),
+            _ if arg.starts_with("--tessdata=") => {
+                tessdata = Some(PathBuf::from(&arg["--tessdata=".len()..]))
+            }
+            _ if arg.starts_with("--output=") => output = parse_output(&arg["--output=".len()..])?,
+            _ if arg.starts_with('-') && arg.len() > 1 => {
+                return Err(format!("unknown option: {arg}"));
+            }
+            _ => {
+                if image.is_some() {
+                    return Err("only one image file is supported".to_string());
+                }
+                image = Some(PathBuf::from(arg));
+            }
+        }
+        i += 1;
+    }
+
+    Ok(Options {
+        image: image.ok_or("missing IMAGE argument (see --help)")?,
+        lang,
+        psm,
+        tessdata,
+        output,
+    })
+}
+
+fn parse_psm(value: &str) -> Result<i32, String> {
+    let psm = value
+        .parse::<i32>()
+        .map_err(|_| format!("invalid --psm value: {value} (expected 0-13)"))?;
+    if !(0..=13).contains(&psm) {
+        return Err(format!("invalid --psm value: {psm} (expected 0-13)"));
+    }
+    Ok(psm)
+}
+
+fn parse_output(value: &str) -> Result<OutputFormat, String> {
+    match value {
+        "txt" => Ok(OutputFormat::Txt),
+        "hocr" => Ok(OutputFormat::Hocr),
+        "tsv" => Ok(OutputFormat::Tsv),
+        other => Err(format!(
+            "unknown output format: {other} (expected txt, hocr or tsv)"
+        )),
+    }
+}
+
+fn run(opts: &Options) -> Result<(), Box<dyn std::error::Error>> {
+    let img = image::open(&opts.image)?.to_luma8();
+    let (width, height) = img.dimensions();
+
+    let tessdata = match opts.tessdata.clone().or_else(resolve_tessdata) {
+        Some(dir) => dir,
+        None => {
+            return Err(
+                "unable to find a tessdata directory; pass --tessdata <DIR> or set TESSDATA_PREFIX"
+                    .into(),
+            );
+        }
+    };
+
+    let api = TesseractAPI::new();
+    api.init(tessdata.to_str().unwrap_or(""), &opts.lang)?;
+
+    if let Some(psm) = opts.psm {
+        api.set_page_seg_mode(TessPageSegMode::from_int(psm))?;
+    }
+
+    api.set_image(img.as_raw(), width as i32, height as i32, 1, width as i32)?;
+
+    let text = match opts.output {
+        OutputFormat::Txt => api.get_utf8_text()?,
+        OutputFormat::Hocr => api.get_hocr_text(0)?,
+        OutputFormat::Tsv => api.get_tsv_text(0)?,
+    };
+    print!("{text}");
+
+    Ok(())
+}
+
+/// Resolve the tessdata directory, in order:
+/// 1. `TESSDATA_PREFIX` env var
+/// 2. `tesseract --print-tessdata-dir` (supported by some builds)
+/// 3. Common locations (bundled-build dirs, Homebrew, distro defaults),
+///    validated by the presence of `eng.traineddata`
+fn resolve_tessdata() -> Option<PathBuf> {
+    if let Ok(dir) = env::var("TESSDATA_PREFIX") {
+        if !dir.is_empty() {
+            return Some(PathBuf::from(dir));
+        }
+    }
+
+    if let Ok(output) = Command::new("tesseract")
+        .arg("--print-tessdata-dir")
+        .output()
+    {
+        if output.status.success() {
+            let dir = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if is_absolute_path(&dir) {
+                return Some(PathBuf::from(dir));
+            }
+        }
+    }
+
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if cfg!(target_os = "macos") {
+        if let Ok(home) = env::var("HOME") {
+            candidates.push(
+                PathBuf::from(home).join("Library/Application Support/tesseract-rs/tessdata"),
+            );
+        }
+        candidates.push(PathBuf::from("/opt/homebrew/share/tessdata"));
+        candidates.push(PathBuf::from("/usr/local/share/tessdata"));
+        candidates.push(PathBuf::from("/usr/share/tessdata"));
+    } else if cfg!(target_os = "linux") || cfg!(target_os = "freebsd") {
+        if let Ok(home) = env::var("HOME") {
+            candidates.push(PathBuf::from(home).join(".tesseract-rs/tessdata"));
+        }
+        candidates.push(PathBuf::from("/usr/share/tessdata"));
+        candidates.push(PathBuf::from("/usr/share/tesseract-ocr/5/tessdata"));
+        candidates.push(PathBuf::from("/usr/share/tesseract-ocr/4.00/tessdata"));
+    } else if cfg!(target_os = "windows") {
+        if let Ok(appdata) = env::var("APPDATA") {
+            candidates.push(PathBuf::from(appdata).join("tesseract-rs/tessdata"));
+        }
+    }
+
+    candidates
+        .into_iter()
+        .find(|dir| dir.join("eng.traineddata").exists())
+}
+
+fn is_absolute_path(value: &str) -> bool {
+    value.starts_with('/')
+        || (cfg!(target_os = "windows") && value.len() > 2 && value.as_bytes()[1] == b':')
+}

--- a/src/api.rs
+++ b/src/api.rs
@@ -865,14 +865,13 @@ impl TesseractAPI {
                 std::ptr::null_mut(), // renderer
             )
         };
-        if result.is_null() {
-            Err(TesseractError::ProcessPagesError)
-        } else {
-            let c_str = unsafe { CStr::from_ptr(result) };
-            let output = c_str.to_str()?.to_owned();
-            unsafe { TessDeleteText(result) };
-            Ok(output)
+        // TessBaseAPIProcessPages returns BOOL (0 = failure); the recognized
+        // text is fetched separately via GetUTF8Text.
+        if result == 0 {
+            return Err(TesseractError::ProcessPagesError);
         }
+        drop(handle);
+        self.get_utf8_text()
     }
 
     /// Gets the initial languages as a string.
@@ -1613,7 +1612,7 @@ extern "C" {
         retry_config: *const c_char,
         timeout_millisec: c_int,
         renderer: *mut c_void,
-    ) -> *mut c_char;
+    ) -> c_int;
 
     fn TessBaseAPIGetInputName(handle: *mut c_void) -> *const c_char;
     fn TessBaseAPISetInputName(handle: *mut c_void, name: *const c_char);


### PR DESCRIPTION
## Summary

Three changes in one release (0.4.0):

### 1. `use-system-tesseract` feature
Link against a system-installed Tesseract (Homebrew, `libtesseract-dev`, ...)
via pkg-config instead of compiling the bundled sources — build times drop
from minutes to seconds:

```toml
tesseract-rs = { version = "0.4.0", default-features = false, features = ["use-system-tesseract"] }
```

### 2. `tesseract-rs-cli` command-line tool
New workspace crate shipping a `tesseract-rs` binary:

```sh
cargo install tesseract-rs-cli
# or with a system Tesseract:
cargo install tesseract-rs-cli --no-default-features --features use-system-tesseract

tesseract-rs image.png
tesseract-rs -l eng+tur --psm 6 -o hocr scanned.png
```

### 3. ProcessPages FFI fix (SIGSEGV)
`TessBaseAPIProcessPages` returns `BOOL` (int) in the C API, but the binding
declared `*mut c_char`. On success the value `1` was treated as a pointer and
dereferenced → SIGSEGV with tesseract 5.5.3 (the bundled 5.5.2 masked it via
the error path). Found while running the test suite against a system
Tesseract. Text is now fetched via `GetUTF8Text`.

## Verification

- Bundled mode: full test suite passes (182 tests)
- System mode (`use-system-tesseract` against Homebrew tesseract 5.5.3):
  full test suite passes, CLI links `libtesseract.5.dylib` and OCRs
  correctly
- clippy clean in both modes, `cargo fmt --check` clean
